### PR TITLE
Fix in bin for execute as python3

### DIFF
--- a/bin/dasadd
+++ b/bin/dasadd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import sys

--- a/bin/dasedit
+++ b/bin/dasedit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/bin/daseval
+++ b/bin/daseval
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import sys

--- a/bin/dasget
+++ b/bin/dasget
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import sys

--- a/bin/dasrm
+++ b/bin/dasrm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import sys

--- a/bin/dasset
+++ b/bin/dasset
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import sys


### PR DESCRIPTION
It will be executed in python2 depending on the python symlink. 
It seems that it is necessary to definitely start it as python3.