### PR TITLE
Fix bug about dynaimic class on python3

### DIFF
--- a/python/das/__init__.py
+++ b/python/das/__init__.py
@@ -5,7 +5,7 @@ import datetime
 import typing
 from typing import Any, List, Union, Optional
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __verbose__ = False
 try:
    __verbose__ = (int(os.environ.get("DAS_VERBOSE", "0")) != 0)

--- a/python/das/schematypes.py
+++ b/python/das/schematypes.py
@@ -1267,6 +1267,8 @@ class Class(TypeValidator):
          if c is None:
             g = globals()
             if not i in g:
+               # TODO: We must change imp to importlib. The imp module is deprecated in favor of importlib.(Deprecated since version 3.4)
+               # https://docs.python.org/3.10/library/imp.html
                c = imp.load_module(i, *imp.find_module(i))
             else:
                c = globals()[i]

--- a/python/das/validation.py
+++ b/python/das/validation.py
@@ -1,12 +1,28 @@
 import os
 import re
 import sys
-import imp
+import importlib
 import glob
 import copy
 import das
 from typing import Any, Dict, List, Optional, Set, TYPE_CHECKING
 
+def load_source(modname, filename):
+   import importlib.util
+   import importlib.machinery
+
+   loader = importlib.machinery.SourceFileLoader(modname, filename)
+   spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+
+   module = importlib.util.module_from_spec(spec)
+
+   # The module is always executed and not cached in sys.modules.
+   # Uncomment the following line to cache the module.
+   sys.modules[module.__name__] = module
+   # loader.exec_module(module)
+   spec.loader.exec_module(module)
+
+   return module
 
 if sys.version_info.major >= 3:
    def cmp(a, b):
@@ -69,7 +85,7 @@ class Schema(object):
       if os.path.isfile(pmp):
          try:
             modname = os.path.splitext(os.path.basename(self.path))[0]
-            mod = imp.load_source("das.schema.%s" % modname, pmp)
+            mod = load_source("das.schema.%s" % modname, pmp)
          except Exception as e:
             import traceback
             print("[das] Failed to load schema module '%s' (%s)" % (pmp, e))

--- a/python/das/validation.py
+++ b/python/das/validation.py
@@ -7,12 +7,12 @@ import copy
 import das
 from typing import Any, Dict, List, Optional, Set, TYPE_CHECKING
 
-def load_source(modname, filename):
+def load_source(modname, filepath):
    import importlib.util
    import importlib.machinery
 
-   loader = importlib.machinery.SourceFileLoader(modname, filename)
-   spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+   loader = importlib.machinery.SourceFileLoader(modname, filepath)
+   spec = importlib.util.spec_from_file_location(modname, filepath, loader=loader)
 
    module = importlib.util.module_from_spec(spec)
 


### PR DESCRIPTION
Summary
- Change imp to importlib (and I couldn't understand what the _class function wanted to do, so I wrote it as TODO.)
- Fix bug module instance about dynamic class on python3